### PR TITLE
Fixed the bug that did not show in the PR comments the lines affected by the periphery scan.

### DIFF
--- a/Sources/DangerSwiftPeriphery/DangerPeriphery.swift
+++ b/Sources/DangerSwiftPeriphery/DangerPeriphery.swift
@@ -60,7 +60,7 @@ public struct DangerPeriphery {
                     return false
                 case let .modified(hunks):
                     return hunks.contains(where: {
-                        let lineRange = ($0.newLineStart ..< $0.newLineSpan - $0.newLineStart)
+                        let lineRange = ($0.newLineStart ..< $0.newLineStart + $0.newLineSpan)
                         if lineRange.contains(violation.line) {
                             return true
                         }


### PR DESCRIPTION
Periphery is running correctly, but I couldn't find the correct lines to add the comments.