### PR TITLE
Use periphery with SwiftPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML",
+        "state": {
+          "branch": null,
+          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+          "version": "4.6.1"
+        }
+      },
+      {
         "package": "Logger",
         "repositoryURL": "https://github.com/shibapm/Logger",
         "state": {
@@ -20,6 +29,24 @@
         }
       },
       {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "Periphery",
+        "repositoryURL": "https://github.com/peripheryapp/periphery",
+        "state": {
+          "branch": null,
+          "revision": "e0299f529984a3d34122ad32d3e53b2607fc67d6",
+          "version": "2.9.0"
+        }
+      },
+      {
         "package": "RequestKit",
         "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
         "state": {
@@ -29,12 +56,57 @@
         }
       },
       {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
+        }
+      },
+      {
         "package": "danger-swift",
         "repositoryURL": "https://github.com/danger/swift.git",
         "state": {
           "branch": null,
-          "revision": "c1bba33f705ca0fd4a0022997c8b696210083755",
-          "version": "3.12.3"
+          "revision": "36fc10dd9d02f09cf61cad6231a3f414d0d997d2",
+          "version": "3.13.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "df9ee6676cd5b3bf5b330ec7568a5644f547201b",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "package": "SwiftIndexStore",
+        "repositoryURL": "https://github.com/kateinoigakukun/swift-indexstore",
+        "state": {
+          "branch": null,
+          "revision": "ea41d13796dbbc4dc36d97ba5edb20a021aaf4e4",
+          "version": "0.1.5"
+        }
+      },
+      {
+        "package": "SwiftSyntax",
+        "repositoryURL": "https://github.com/peripheryapp/swift-syntax",
+        "state": {
+          "branch": null,
+          "revision": "8a82bdb5d1558d130f732ef9f27dc1cd6f6696ea",
+          "version": "0.50600.1-static"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system",
+        "state": {
+          "branch": null,
+          "revision": "025bcb1165deab2e20d4eaba79967ce73013f496",
+          "version": "1.2.1"
         }
       },
       {
@@ -42,8 +114,26 @@
         "repositoryURL": "https://github.com/mxcl/Version",
         "state": {
           "branch": null,
-          "revision": "200046c93f6d5d78a6d72bfd9c0b27a95e9c0a2b",
-          "version": "1.2.0"
+          "revision": "1fe824b80d89201652e7eca7c9252269a1d85e25",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "package": "XcodeProj",
+        "repositoryURL": "https://github.com/tuist/xcodeproj",
+        "state": {
+          "branch": null,
+          "revision": "b6de1bfe021b861c94e7c83821b595083f74b997",
+          "version": "8.8.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams",
+        "state": {
+          "branch": null,
+          "revision": "01835dc202670b5bb90d07f3eae41867e9ed29f6",
+          "version": "5.0.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,15 @@ let package = Package(
             targets: ["DangerSwiftPeriphery"]),
     ],
     dependencies: [
-        .package(name: "danger-swift", url: "https://github.com/danger/swift.git", from: "3.0.0")
+        .package(url: "https://github.com/danger/swift.git", from: "3.0.0"),
+        .package(url: "https://github.com/peripheryapp/periphery", from: "2.0.0")
     ],
     targets: [
         .target(
             name: "DangerSwiftPeriphery",
             dependencies: [
-                .product(name: "Danger", package: "danger-swift")
+                .product(name: "Danger", package: "swift"),
+                .product(name: "periphery", package: "periphery"),
             ]),
         .testTarget(
             name: "DangerSwiftPeripheryTests",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This plugin will comment unreferenced code detected by periphery via Danger Swif
 
 ### Preparation
 
-- Install [Periphery](https://github.com/peripheryapp/periphery) on the machine you want to run Danger Swift on beforehand.
 - [Danger Swift](https://github.com/danger/swift) Setup.
 
 ### Package.swift
@@ -76,7 +75,7 @@ You may also specify the location of periphery binaries.
 ```swift
 import DangerSwiftPeriphery
 
-DangerPeriphery.scan(peripheryPath: "/path/to/periphery")
+DangerPeriphery.scan(peripheryExecutable: "/path/to/periphery")
 ```
 
 

--- a/Sources/DangerSwiftPeriphery/DangerPeriphery.swift
+++ b/Sources/DangerSwiftPeriphery/DangerPeriphery.swift
@@ -8,10 +8,10 @@
 import Danger
 
 public struct DangerPeriphery {
-    public static func scan(peripheryPath: String = "periphery",
+    public static func scan(peripheryExecutable: String = "swift run periphery",
                             arguments: [String] = []) {
         // make dependencies
-        let commandBuilder = PeripheryScanCommandBuilder(peripheryPath: peripheryPath,
+        let commandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: peripheryExecutable,
                                                          additionalArguments: arguments)
         let scanExecutor = PeripheryScanExecutor(commandBuilder: commandBuilder)
         let diffProvider = PullRequestDiffProvider(dangerDSL: Danger())

--- a/Sources/DangerSwiftPeriphery/PeripheryScanCommandBuilder.swift
+++ b/Sources/DangerSwiftPeriphery/PeripheryScanCommandBuilder.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PeripheryScanCommandBuilder {
-    private let peripheryPath: String
+    private let peripheryExecutable: String
     private let additionalArguments: [String]
     private let overrideArgumentKeys: [String] = [
         "--format",
@@ -28,12 +28,12 @@ struct PeripheryScanCommandBuilder {
             "--disable-update-check"
         ]
         
-        return peripheryPath + " scan " + overridedArguments.joined(separator: " ")
+        return peripheryExecutable + " scan " + overridedArguments.joined(separator: " ")
     }
     
-    init(peripheryPath: String,
+    init(peripheryExecutable: String,
          additionalArguments: [String]) {
-        self.peripheryPath = peripheryPath
+        self.peripheryExecutable = peripheryExecutable
         self.additionalArguments = additionalArguments
     }
 }

--- a/Tests/DangerSwiftPeripheryTests/PeripheryScanCommandBuilderTests.swift
+++ b/Tests/DangerSwiftPeripheryTests/PeripheryScanCommandBuilderTests.swift
@@ -20,25 +20,25 @@ final class PeripheryScanCommandBuilderTests: XCTestCase {
     }
 
     func testPerihperyPath() throws {
-        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryPath: "test/path/to/periphery", additionalArguments: [])
+        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "test/path/to/periphery", additionalArguments: [])
         
         XCTAssertEqual(scanCommandBuilder.command, "test/path/to/periphery scan --format checkstyle --quiet --disable-update-check")
     }
     
     func testAdditionalArgumantsNoOverride() throws {
-        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryPath: "periphery", additionalArguments: ["--test-arg1", "--test-arg2 value"])
+        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "periphery", additionalArguments: ["--test-arg1", "--test-arg2 value"])
         
         XCTAssertEqual(scanCommandBuilder.command, "periphery scan --test-arg1 --test-arg2 value --format checkstyle --quiet --disable-update-check")
     }
     
     func testAdditionalArgumantsOverride() throws {
-        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryPath: "periphery", additionalArguments: ["--format json"])
+        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "periphery", additionalArguments: ["--format json"])
         
         XCTAssertEqual(scanCommandBuilder.command, "periphery scan --format checkstyle --quiet --disable-update-check")
     }
     
     func testAdditionalArgumantsDuplicate() throws {
-        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryPath: "periphery", additionalArguments: ["--quiet", "--disable-update-check"])
+        scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "periphery", additionalArguments: ["--quiet", "--disable-update-check"])
         
         XCTAssertEqual(scanCommandBuilder.command, "periphery scan --format checkstyle --quiet --disable-update-check")
     }

--- a/Tests/DangerSwiftPeripheryTests/PeripheryScanCommandBuilderTests.swift
+++ b/Tests/DangerSwiftPeripheryTests/PeripheryScanCommandBuilderTests.swift
@@ -19,25 +19,25 @@ final class PeripheryScanCommandBuilderTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testPerihperyPath() throws {
+    func testPeripheryExecutable() throws {
         scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "test/path/to/periphery", additionalArguments: [])
         
         XCTAssertEqual(scanCommandBuilder.command, "test/path/to/periphery scan --format checkstyle --quiet --disable-update-check")
     }
     
-    func testAdditionalArgumantsNoOverride() throws {
+    func testAdditionalArgumentsNoOverride() throws {
         scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "periphery", additionalArguments: ["--test-arg1", "--test-arg2 value"])
         
         XCTAssertEqual(scanCommandBuilder.command, "periphery scan --test-arg1 --test-arg2 value --format checkstyle --quiet --disable-update-check")
     }
     
-    func testAdditionalArgumantsOverride() throws {
+    func testAdditionalArgumentsOverride() throws {
         scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "periphery", additionalArguments: ["--format json"])
         
         XCTAssertEqual(scanCommandBuilder.command, "periphery scan --format checkstyle --quiet --disable-update-check")
     }
     
-    func testAdditionalArgumantsDuplicate() throws {
+    func testAdditionalArgumentsDuplicate() throws {
         scanCommandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "periphery", additionalArguments: ["--quiet", "--disable-update-check"])
         
         XCTAssertEqual(scanCommandBuilder.command, "periphery scan --format checkstyle --quiet --disable-update-check")

--- a/Tests/DangerSwiftPeripheryTests/PeripheryScanExecutorTests.swift
+++ b/Tests/DangerSwiftPeripheryTests/PeripheryScanExecutorTests.swift
@@ -13,7 +13,7 @@ final class PeripheryScanExecutorTests: XCTestCase {
     private var commandBuilder: PeripheryScanCommandBuilder!
     
     override func setUpWithError() throws {
-        commandBuilder = PeripheryScanCommandBuilder(peripheryPath: "", additionalArguments: [])
+        commandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: "", additionalArguments: [])
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
periphery can be used through SwiftPM without prior installation.