### PR TITLE
Use enum for scan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ DangerPeriphery.scan(arguments: [
 // or use PeripheryArguments enum as array
 DangerPeriphery.scan(arguments: [
     PeripheryArguments.workspace("MaApp.xcworkspace"),
-    PeripheryArgumens.schemes(["MyApp"]),
-    PeripheryArgumens.indexStorePath("/path/to/index/store"),
+    PeripheryArguments.schemes(["MyApp"]),
+    PeripheryArguments.indexStorePath("/path/to/index/store"),
     PeripheryArguments.skipBuild
 ])
 
 // or use PeripheryArguments enum with resultBuilder
 DangerPeriphery.scan {
     PeripheryArguments.workspace("MaApp.xcworkspace")
-    PeripheryArgumens.schemes(["MyApp"])
-    PeripheryArgumens.indexStorePath("/path/to/index/store")
+    PeripheryArguments.schemes(["MyApp"])
+    PeripheryArguments.indexStorePath("/path/to/index/store")
     PeripheryArguments.skipBuild
 }
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ let package = Package(
 
 ### Dangerfile.swift
 
+#### Set scan options
+
 If you have a `.periphery.yml` file, simply include the following in `Dangerfile.swift`
 
 ```swift
@@ -68,7 +70,30 @@ DangerPeriphery.scan(arguments: [
     "--index-store-path /path/to/index/store",
     "--skip-build"
 ])
+
+// or use PeripheryArguments enum as array
+DangerPeriphery.scan(arguments: [
+    PeripheryArguments.workspace("MaApp.xcworkspace"),
+    PeripheryArgumens.schemes(["MyApp"]),
+    PeripheryArgumens.indexStorePath("/path/to/index/store"),
+    PeripheryArguments.skipBuild
+])
+
+// or use PeripheryArguments enum with resultBuilder
+DangerPeriphery.scan {
+    PeripheryArguments.workspace("MaApp.xcworkspace")
+    PeripheryArgumens.schemes(["MyApp"])
+    PeripheryArgumens.indexStorePath("/path/to/index/store")
+    PeripheryArguments.skipBuild
+}
+
+// All three scan methods above behave the same.
 ```
+
+In the future, if a new option is added to Periphery, and it is undefined in this plugin, you can use `.custom`.
+For example, if a new version of Periphery adds an option `--new-option` that is undefined in `PeripheryArguments` of this plugin, you can use `PeripheryArguments.custom("--new-option foo")` to use `--new-option`.
+
+#### Specify periphery executable
 
 You may also specify the location of periphery binaries.
 

--- a/Sources/DangerSwiftPeriphery/DangerPeriphery.swift
+++ b/Sources/DangerSwiftPeriphery/DangerPeriphery.swift
@@ -9,6 +9,18 @@ import Danger
 
 public struct DangerPeriphery {
     public static func scan(peripheryExecutable: String = "swift run periphery",
+                            @PeripheryArgumentsBuilder arguments: () -> [String] = { [] }) {
+        scan(peripheryExecutable: peripheryExecutable,
+             arguments: arguments())
+    }
+
+    public static func scan(peripheryExecutable: String = "swift run periphery",
+                            arguments: [PeripheryArguments] = []) {
+        scan(peripheryExecutable: peripheryExecutable,
+             arguments: arguments.map { $0.optionString })
+    }
+
+    public static func scan(peripheryExecutable: String = "swift run periphery",
                             arguments: [String] = []) {
         // make dependencies
         let commandBuilder = PeripheryScanCommandBuilder(peripheryExecutable: peripheryExecutable,

--- a/Sources/DangerSwiftPeriphery/PeripheryArguments.swift
+++ b/Sources/DangerSwiftPeriphery/PeripheryArguments.swift
@@ -1,0 +1,82 @@
+//
+// Created by 多鹿豊 on 2022/07/25.
+//
+
+import Foundation
+
+public enum PeripheryArguments {
+    case config(String)
+    case workspace(String)
+    case project(String)
+    case schemes([String])
+    case targets([String])
+    case indexExclude([String])
+    case reportExclude([String])
+    case reportInclude([String])
+    case indexStorePath(String)
+    case retainPublic
+    case disableRedundantPublicAnalysis
+    case retainAssignOnlyProperties
+    case retainAssignOnlyPropertyTypes([String])
+    case externalEncodableProtocols([String])
+    case retainObjcAccessible
+    case retainUnusedProtocolFuncParams
+    case cleanBuild
+    case skipBuild
+    case strict
+    case custom(String)
+}
+
+public extension PeripheryArguments {
+    var optionString: String {
+        if case let .custom(value) = self {
+            return value
+        }
+        if values.isEmpty {
+            return key
+        } else {
+            return values
+                .map { [key, $0].joined(separator: " ") }
+                .joined(separator: " ")
+        }
+    }
+}
+
+private extension PeripheryArguments {
+    var key: String {
+        let reflection = Mirror(reflecting: self)
+        guard reflection.displayStyle == .enum,
+              let associated = reflection.children.first else {
+            return "--" + "\(self)".kebabCased
+        }
+        return "--" + associated.label!.kebabCased
+    }
+
+    var values: [String] {
+        let reflection = Mirror(reflecting: self)
+        guard reflection.displayStyle == .enum,
+              let associated = reflection.children.first else {
+            return []
+        }
+        switch associated.value {
+        case let value as String:
+            return [value]
+        case let values as [String]:
+            return values
+        default:
+            return []
+        }
+    }
+}
+
+private extension String {
+    var kebabCased: String {
+        let pattern = "([a-z0-9])([A-Z])"
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return self
+        }
+        let range = NSRange(location: 0, length: count)
+        return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1-$2").lowercased()
+    }
+}

--- a/Sources/DangerSwiftPeriphery/PeripheryArgumentsBuilder.swift
+++ b/Sources/DangerSwiftPeriphery/PeripheryArgumentsBuilder.swift
@@ -1,0 +1,36 @@
+//
+// Created by 多鹿豊 on 2022/07/26.
+//
+
+import Foundation
+
+@resultBuilder
+public struct PeripheryArgumentsBuilder {
+    public static func buildBlock(_ components: PeripheryArguments...) -> [PeripheryArguments] {
+        components
+    }
+
+    public static func buildEither(first component: [PeripheryArguments]) -> PeripheryArguments {
+        component.first ?? .custom("")
+    }
+
+    public static func buildEither(second component: [PeripheryArguments]) -> PeripheryArguments {
+        component.first ?? .custom("")
+    }
+
+    public static func buildOptional(_ component: [PeripheryArguments]?) -> PeripheryArguments {
+        component?.first ?? .custom("")
+    }
+
+    public static func buildFinalResult(_ component: [PeripheryArguments]) -> [String] {
+        component.compactMap { $0.optionString.isEmpty ? nil : $0.optionString }
+    }
+
+    public static func buildArray(_ components: [[PeripheryArguments]]) -> PeripheryArguments {
+        .custom(
+            components
+                .flatMap { $0.map { $0.optionString } }
+                .joined(separator: " ")
+        )
+    }
+}

--- a/Tests/DangerSwiftPeripheryTests/PeripheryArgumentsBuilderTests.swift
+++ b/Tests/DangerSwiftPeripheryTests/PeripheryArgumentsBuilderTests.swift
@@ -1,0 +1,98 @@
+//
+// Created by 多鹿豊 on 2022/07/27.
+//
+
+import XCTest
+@testable import DangerSwiftPeriphery
+
+final class PeripheryArgumentsBuilderTests: XCTestCase {
+    private let trueCondition = true
+    private let falseCondition = false
+
+    func testBuildBlock() {
+        assert({
+            PeripheryArguments.config("/path/to/config")
+            PeripheryArguments.workspace("test-workspace")
+            PeripheryArguments.schemes(["scheme1", "scheme2"])
+            PeripheryArguments.skipBuild
+        }, expected: [
+            "--config /path/to/config",
+            "--workspace test-workspace",
+            "--schemes scheme1 --schemes scheme2",
+            "--skip-build"
+        ])
+    }
+
+    func testBuildOptionalTrueCondition() {
+        assert({
+            PeripheryArguments.config("/path/to/config")
+            PeripheryArguments.workspace("test-workspace")
+            if trueCondition {
+                PeripheryArguments.schemes(["scheme1", "scheme2"])
+            }
+            PeripheryArguments.skipBuild
+        }, expected: [
+            "--config /path/to/config",
+            "--workspace test-workspace",
+            "--schemes scheme1 --schemes scheme2",
+            "--skip-build"
+        ])
+    }
+
+    func testBuildOptionalFalseCondition() {
+        assert({
+            PeripheryArguments.config("/path/to/config")
+            PeripheryArguments.workspace("test-workspace")
+            if falseCondition {
+                PeripheryArguments.schemes(["scheme1", "scheme2"])
+            }
+            PeripheryArguments.skipBuild
+        }, expected: [
+            "--config /path/to/config",
+            "--workspace test-workspace",
+            "--skip-build"
+        ])
+    }
+
+    func testBuildEitherFirst() {
+        assert({
+            PeripheryArguments.config("/path/to/config")
+            PeripheryArguments.workspace("test-workspace")
+            if trueCondition {
+                PeripheryArguments.schemes(["scheme1", "scheme2"])
+            } else {
+                PeripheryArguments.schemes(["scheme3", "scheme4"])
+            }
+            PeripheryArguments.skipBuild
+        }, expected: [
+            "--config /path/to/config",
+            "--workspace test-workspace",
+            "--schemes scheme1 --schemes scheme2",
+            "--skip-build"
+        ])
+    }
+
+    func testBuildEitherSecond() {
+        assert({
+            PeripheryArguments.config("/path/to/config")
+            PeripheryArguments.workspace("test-workspace")
+            if falseCondition {
+                PeripheryArguments.schemes(["scheme1", "scheme2"])
+            } else {
+                PeripheryArguments.schemes(["scheme3", "scheme4"])
+            }
+            PeripheryArguments.skipBuild
+        }, expected: [
+            "--config /path/to/config",
+            "--workspace test-workspace",
+            "--schemes scheme3 --schemes scheme4",
+            "--skip-build"
+        ])
+    }
+}
+
+private extension PeripheryArgumentsBuilderTests {
+    func assert(@PeripheryArgumentsBuilder _ arguments: () -> [String], expected: [String]) {
+        XCTAssertEqual(arguments(), expected)
+    }
+}

--- a/Tests/DangerSwiftPeripheryTests/PeripheryArgumentsTests.swift
+++ b/Tests/DangerSwiftPeripheryTests/PeripheryArgumentsTests.swift
@@ -1,0 +1,39 @@
+//
+// Created by 多鹿豊 on 2022/07/27.
+//
+
+import XCTest
+@testable import DangerSwiftPeriphery
+
+final class PeripheryArgumentsTests: XCTestCase {
+    func testPeripheryArgumentsOptionsString() {
+        var optionStringTable: [(target: PeripheryArguments, expected: String)] {
+            [
+                (.config("/path/to/config"), "--config /path/to/config"),
+                (.workspace("test-workspace"), "--workspace test-workspace"),
+                (.project("test-project"), "--project test-project"),
+                (.schemes(["test-scheme1", "test-scheme2"]), "--schemes test-scheme1 --schemes test-scheme2"),
+                (.targets(["test-target1", "test-target2"]), "--targets test-target1 --targets test-target2"),
+                (.indexExclude(["index-exclude1", "index-exclude2"]), "--index-exclude index-exclude1 --index-exclude index-exclude2"),
+                (.reportExclude(["report-exclude1", "report-exclude2"]), "--report-exclude report-exclude1 --report-exclude report-exclude2"),
+                (.reportInclude(["report-include1", "report-include2"]), "--report-include report-include1 --report-include report-include2"),
+                (.indexStorePath("/path/to/index-store"), "--index-store-path /path/to/index-store"),
+                (.retainPublic, "--retain-public"),
+                (.disableRedundantPublicAnalysis, "--disable-redundant-public-analysis"),
+                (.retainAssignOnlyProperties, "--retain-assign-only-properties"),
+                (.retainAssignOnlyPropertyTypes(["type1", "type2"]), "--retain-assign-only-property-types type1 --retain-assign-only-property-types type2"),
+                (.externalEncodableProtocols(["protocol1", "protocol2"]), "--external-encodable-protocols protocol1 --external-encodable-protocols protocol2"),
+                (.retainObjcAccessible, "--retain-objc-accessible"),
+                (.retainUnusedProtocolFuncParams, "--retain-unused-protocol-func-params"),
+                (.cleanBuild, "--clean-build"),
+                (.skipBuild, "--skip-build"),
+                (.strict, "--strict"),
+                (.custom("--test test"), "--test test"),
+            ]
+        }
+
+        for item in optionStringTable {
+            XCTAssertEqual(item.target.optionString, item.expected)
+        }
+    }
+}


### PR DESCRIPTION
- define periphery scan options as enum named `PeripheryArguments`
- add new scan methods with `PeripheryArguments`